### PR TITLE
[GP-15] feat: Implement MySQL output ports

### DIFF
--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/configs/security/SecurityConfig.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/configs/security/SecurityConfig.java
@@ -24,8 +24,8 @@ public class SecurityConfig {
     private final AuthenticationEntryPoint authenticationEntryPoint;
 
     public static final String[] publicEndpoints = {
-            "/health",
-            "/swagger/**", "/swagger-ui/**"
+            "/gemini/health",
+            "/swagger/**", "/swagger-ui/**", "/v3/api-docs/**"
     };
 
     @Bean

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/ConversationEntity.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/ConversationEntity.java
@@ -1,8 +1,23 @@
 package com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities;
 
 import com.tranphuc8a.gemini_proxy.domain.models.Conversation;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.PreUpdate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 
 import java.time.LocalDateTime;
@@ -34,22 +49,30 @@ public class ConversationEntity implements TableEntity<Conversation> {
     List<MessageEntity> messages;
 
     @PrePersist
-    public void preInsert(){
+    public void preInsert() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
     }
 
     @PreUpdate
-    public void preUpdate(){
+    public void preUpdate() {
         updatedAt = LocalDateTime.now();
     }
 
     @PostLoad
-    public void postLoad(){
-        if (name == null) name = "";
-        if (messages == null) messages = List.of();
-        if (createdAt == null) createdAt = LocalDateTime.now();
-        if (updatedAt == null) updatedAt = LocalDateTime.now();
+    public void postLoad() {
+        if (name == null) {
+            name = "";
+        }
+        if (messages == null) {
+            messages = List.of();
+        }
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+        if (updatedAt == null) {
+            updatedAt = LocalDateTime.now();
+        }
     }
 
 
@@ -76,7 +99,9 @@ public class ConversationEntity implements TableEntity<Conversation> {
 
     @Override
     public ConversationEntity fromDomain(Conversation domain) {
-        if (domain == null) return this;
+        if (domain == null) {
+            return this;
+        }
         fromDomainLight(domain);
         messages = domain.getMessages().stream().map(
                 message -> new MessageEntity().fromDomainLight(message)).toList();
@@ -85,7 +110,9 @@ public class ConversationEntity implements TableEntity<Conversation> {
 
     @Override
     public ConversationEntity fromDomainLight(Conversation domain) {
-        if (domain == null) return this;
+        if (domain == null) {
+            return this;
+        }
         id = domain.getId();
         name = domain.getName();
         createdAt = domain.getCreatedAt();

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/ConversationEntity.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/ConversationEntity.java
@@ -1,0 +1,95 @@
+package com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities;
+
+import com.tranphuc8a.gemini_proxy.domain.models.Conversation;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Entity(name = "conversations")
+public class ConversationEntity implements TableEntity<Conversation> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    String id;
+
+    @Column(nullable = false)
+    String name;
+
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "conversation", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    List<MessageEntity> messages;
+
+    @PrePersist
+    public void preInsert(){
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate(){
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PostLoad
+    public void postLoad(){
+        if (name == null) name = "";
+        if (messages == null) messages = List.of();
+        if (createdAt == null) createdAt = LocalDateTime.now();
+        if (updatedAt == null) updatedAt = LocalDateTime.now();
+    }
+
+
+    @Override
+    public Conversation toDomain() {
+        return Conversation.builder()
+                .id(id)
+                .name(name)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .messages(messages.stream().map(MessageEntity::toDomainLight).toList())
+                .build();
+    }
+
+    @Override
+    public Conversation toDomainLight() {
+        return Conversation.builder()
+                .id(id)
+                .name(name)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+    }
+
+    @Override
+    public ConversationEntity fromDomain(Conversation domain) {
+        if (domain == null) return this;
+        fromDomainLight(domain);
+        messages = domain.getMessages().stream().map(
+                message -> new MessageEntity().fromDomainLight(message)).toList();
+        return this;
+    }
+
+    @Override
+    public ConversationEntity fromDomainLight(Conversation domain) {
+        if (domain == null) return this;
+        id = domain.getId();
+        name = domain.getName();
+        createdAt = domain.getCreatedAt();
+        updatedAt = domain.getUpdatedAt();
+        return this;
+    }
+}

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/MessageEntity.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/MessageEntity.java
@@ -1,0 +1,92 @@
+package com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities;
+
+import com.tranphuc8a.gemini_proxy.domain.enums.Role;
+import com.tranphuc8a.gemini_proxy.domain.models.Conversation;
+import com.tranphuc8a.gemini_proxy.domain.models.Message;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Entity(name = "messages")
+public class MessageEntity implements TableEntity<Message> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    Integer id;
+
+    @Column(nullable = false)
+    Role role;
+
+    @Column(nullable = false)
+    String content;
+
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "conversation_id", nullable = false)
+    ConversationEntity conversation;
+
+
+    @PrePersist
+    public void preInsert(){
+        createdAt = LocalDateTime.now();
+    }
+
+    @PostLoad
+    public  void postLoad(){
+        if (role == null) role = Role.USER;
+        if (content == null) content = "";
+        if (createdAt == null) createdAt = LocalDateTime.now();
+    }
+
+
+    @Override
+    public Message toDomain() {
+        return Message.builder()
+                .id(id)
+                .content(content)
+                .createdAt(createdAt)
+                .role(role)
+                .conversation(conversation.toDomainLight())
+                .build();
+    }
+
+    @Override
+    public Message toDomainLight() {
+        return Message.builder()
+                .id(id)
+                .content(content)
+                .createdAt(createdAt)
+                .role(role)
+                .build();
+    }
+
+    @Override
+    public MessageEntity fromDomain(Message domain) {
+        if (domain == null) return this;
+        fromDomainLight(domain);
+        conversation = new ConversationEntity().fromDomainLight(domain.getConversation());
+        return this;
+    }
+
+    @Override
+    public MessageEntity fromDomainLight(Message domain) {
+        if (domain == null) return this;
+        id = domain.getId();
+        role = domain.getRole();
+        content = domain.getContent();
+        createdAt = domain.getCreatedAt();
+        return this;
+    }
+
+}

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/MessageEntity.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/MessageEntity.java
@@ -1,14 +1,25 @@
 package com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities;
 
 import com.tranphuc8a.gemini_proxy.domain.enums.Role;
-import com.tranphuc8a.gemini_proxy.domain.models.Conversation;
 import com.tranphuc8a.gemini_proxy.domain.models.Message;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PrePersist;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @Setter
@@ -38,15 +49,21 @@ public class MessageEntity implements TableEntity<Message> {
 
 
     @PrePersist
-    public void preInsert(){
+    public void preInsert() {
         createdAt = LocalDateTime.now();
     }
 
     @PostLoad
-    public  void postLoad(){
-        if (role == null) role = Role.USER;
-        if (content == null) content = "";
-        if (createdAt == null) createdAt = LocalDateTime.now();
+    public void postLoad() {
+        if (role == null) {
+            role = Role.USER;
+        }
+        if (content == null) {
+            content = "";
+        }
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
     }
 
 
@@ -73,7 +90,9 @@ public class MessageEntity implements TableEntity<Message> {
 
     @Override
     public MessageEntity fromDomain(Message domain) {
-        if (domain == null) return this;
+        if (domain == null) {
+            return this;
+        }
         fromDomainLight(domain);
         conversation = new ConversationEntity().fromDomainLight(domain.getConversation());
         return this;
@@ -81,7 +100,9 @@ public class MessageEntity implements TableEntity<Message> {
 
     @Override
     public MessageEntity fromDomainLight(Message domain) {
-        if (domain == null) return this;
+        if (domain == null) {
+            return this;
+        }
         id = domain.getId();
         role = domain.getRole();
         content = domain.getContent();

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/TableEntity.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/TableEntity.java
@@ -1,0 +1,13 @@
+package com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities;
+
+public interface TableEntity<T> {
+
+    T toDomain();
+
+    T toDomainLight();
+
+    TableEntity<T> fromDomain(T domain);
+
+    TableEntity<T> fromDomainLight(T domain);
+
+}

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/repositories/ConversationMySQLRepository.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/repositories/ConversationMySQLRepository.java
@@ -1,0 +1,9 @@
+package com.tranphuc8a.gemini_proxy.adapter.out.mysql.repositories;
+
+import com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities.ConversationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConversationMySQLRepository extends JpaRepository<ConversationEntity, String> {
+}

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/repositories/MessageMySQLRepository.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/repositories/MessageMySQLRepository.java
@@ -1,0 +1,10 @@
+package com.tranphuc8a.gemini_proxy.adapter.out.mysql.repositories;
+
+import com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities.MessageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MessageMySQLRepository extends JpaRepository<MessageEntity, Integer> {
+
+}

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/ConversationMySQLOutputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/ConversationMySQLOutputPort.java
@@ -1,0 +1,48 @@
+package com.tranphuc8a.gemini_proxy.adapter.out.mysql.services;
+
+import com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities.ConversationEntity;
+import com.tranphuc8a.gemini_proxy.adapter.out.mysql.repositories.ConversationMySQLRepository;
+import com.tranphuc8a.gemini_proxy.application.ports.output.ConversationOutputPort;
+import com.tranphuc8a.gemini_proxy.domain.models.Conversation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ConversationMySQLOutputPort implements ConversationOutputPort {
+
+    private final ConversationMySQLRepository conversationMySQLRepository;
+
+    @Override
+    public Conversation getById(String conversationId) {
+        ConversationEntity conversationEntity =
+                conversationMySQLRepository.findById(conversationId).orElse(null);
+        if (conversationEntity == null) return null;
+        return conversationEntity.toDomain();
+    }
+
+    @Override
+    public Page<Conversation> getAll(Pageable pageable) {
+        Page<ConversationEntity> conversationEntityPage = conversationMySQLRepository.findAll(pageable);
+        return conversationEntityPage.map(ConversationEntity::toDomain);
+    }
+
+    @Override
+    public void save(Conversation conversation) {
+        ConversationEntity conversationEntity = new ConversationEntity().fromDomain(conversation);
+        conversationMySQLRepository.save(conversationEntity);
+    }
+
+    @Override
+    public void delete(Conversation conversation) {
+        ConversationEntity conversationEntity = new ConversationEntity().fromDomain(conversation);
+        conversationMySQLRepository.delete(conversationEntity);
+    }
+
+    @Override
+    public void delete(String conversationId) {
+        conversationMySQLRepository.deleteById(conversationId);
+    }
+}

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/ConversationMySQLOutputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/ConversationMySQLOutputPort.java
@@ -19,7 +19,9 @@ public class ConversationMySQLOutputPort implements ConversationOutputPort {
     public Conversation getById(String conversationId) {
         ConversationEntity conversationEntity =
                 conversationMySQLRepository.findById(conversationId).orElse(null);
-        if (conversationEntity == null) return null;
+        if (conversationEntity == null) {
+            return null;
+        }
         return conversationEntity.toDomain();
     }
 

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/MessageMySQLOutputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/MessageMySQLOutputPort.java
@@ -1,0 +1,47 @@
+package com.tranphuc8a.gemini_proxy.adapter.out.mysql.services;
+
+import com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities.MessageEntity;
+import com.tranphuc8a.gemini_proxy.adapter.out.mysql.repositories.MessageMySQLRepository;
+import com.tranphuc8a.gemini_proxy.application.ports.output.MessageOutputPort;
+import com.tranphuc8a.gemini_proxy.domain.models.Message;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MessageMySQLOutputPort implements MessageOutputPort {
+
+    private final MessageMySQLRepository messageMySQLRepository;
+
+    @Override
+    public Message getById(Integer messageId) {
+        MessageEntity messageEntity = messageMySQLRepository.findById(messageId).orElse(null);
+        if (messageEntity == null) return null;
+        return messageEntity.toDomain();
+    }
+
+    @Override
+    public Page<Message> getAll(Pageable pageable) {
+        Page<MessageEntity> messageEntityPage = messageMySQLRepository.findAll(pageable);
+        return messageEntityPage.map(MessageEntity::toDomain);
+    }
+
+    @Override
+    public void save(Message message) {
+        MessageEntity messageEntity = new MessageEntity().fromDomain(message);
+        messageMySQLRepository.save(messageEntity);
+    }
+
+    @Override
+    public void delete(Message message) {
+        MessageEntity messageEntity = new MessageEntity().fromDomain(message);
+        messageMySQLRepository.delete(messageEntity);
+    }
+
+    @Override
+    public void delete(Integer messageId) {
+        messageMySQLRepository.deleteById(messageId);
+    }
+}

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/MessageMySQLOutputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/MessageMySQLOutputPort.java
@@ -18,7 +18,9 @@ public class MessageMySQLOutputPort implements MessageOutputPort {
     @Override
     public Message getById(Integer messageId) {
         MessageEntity messageEntity = messageMySQLRepository.findById(messageId).orElse(null);
-        if (messageEntity == null) return null;
+        if (messageEntity == null) {
+            return null;
+        }
         return messageEntity.toDomain();
     }
 

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/ports/output/ConversationOutputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/ports/output/ConversationOutputPort.java
@@ -1,4 +1,19 @@
 package com.tranphuc8a.gemini_proxy.application.ports.output;
 
+import com.tranphuc8a.gemini_proxy.domain.models.Conversation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface ConversationOutputPort {
+
+    Conversation getById(String conversationId);
+
+    Page<Conversation> getAll(Pageable pageable);
+
+    void save(Conversation conversation);
+
+    void delete(Conversation conversation);
+
+    void delete(String conversationId);
+
 }

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/ports/output/MessageOutputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/ports/output/MessageOutputPort.java
@@ -1,4 +1,19 @@
 package com.tranphuc8a.gemini_proxy.application.ports.output;
 
+import com.tranphuc8a.gemini_proxy.domain.models.Message;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface MessageOutputPort {
+
+    Message getById(Integer messageId);
+
+    Page<Message> getAll(Pageable pageable);
+
+    void save(Message message);
+
+    void delete(Message message);
+
+    void delete(Integer messageId);
+
 }


### PR DESCRIPTION
### Changes

- In **`adapter.out.mysql`**:
  - Implement `ConversationOutputPort`, `MessageOutputPort` and `...MySQLOutputPort`
  - Add MySQL repositories for `Conversation` and `Message`
  - Add entity tables `ConversationEntity` and `MessageEntity`


### Documents

  - Confluence: [Class diagram](https://tranphuc9a.atlassian.net/wiki/x/JQIk)
