### PR TITLE
[GP-13] feat(conversation): add api for managing conversation

### DIFF
--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/configs/ExceptionResolver.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/configs/ExceptionResolver.java
@@ -4,9 +4,12 @@ import com.tranphuc8a.gemini_proxy.domain.exceptions.AppException;
 import com.tranphuc8a.gemini_proxy.domain.exceptions.user.BadRequestException;
 import com.tranphuc8a.gemini_proxy.domain.exceptions.system.InternalServerErrorException;
 import com.tranphuc8a.gemini_proxy.domain.vo.response.ResponseError;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
@@ -35,6 +38,43 @@ public class ExceptionResolver {
         return new ResponseEntity<>(responseError, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    // Handle invalid data access api usage exception
+    @ExceptionHandler(InvalidDataAccessApiUsageException.class)
+    public ResponseEntity<ResponseError<Object>> handleInvalidDataAccessApiUsageException(
+            InvalidDataAccessApiUsageException ex, WebRequest request) {
+        BadRequestException exception = new BadRequestException(ex.getMessage());
+        ResponseError<Object> responseError = ResponseError.from(exception);
+        Map<String, Object> data = new HashMap<>(Map.of(pathKey, getUri(request)));
+        data.put(messageKey, ex.getMessage());
+        responseError.setData(data);
+        return new ResponseEntity<>(responseError, HttpStatus.BAD_REQUEST);
+    }
+
+    // Handle property reference exception
+    @ExceptionHandler(PropertyReferenceException.class)
+    public ResponseEntity<ResponseError<Object>> handlePropertyReferenceException(
+            PropertyReferenceException ex, WebRequest request) {
+        BadRequestException exception = new BadRequestException(ex.getMessage());
+        ResponseError<Object> responseError = ResponseError.from(exception);
+        Map<String, Object> data = new HashMap<>(Map.of(pathKey, getUri(request)));
+        data.put(ex.getPropertyName(), ex.getMessage());
+        responseError.setData(data);
+        return new ResponseEntity<>(responseError, HttpStatus.BAD_REQUEST);
+    }
+
+
+    // Handle missing request params exception
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ResponseError<Object>> handleMissingParamsException(
+            MissingServletRequestParameterException ex, WebRequest request) {
+        BadRequestException exception = new BadRequestException(ex.getMessage());
+        ResponseError<Object> responseError = ResponseError.from(exception);
+        Map<String, Object> data = new HashMap<>(Map.of(pathKey, getUri(request)));
+        data.put(ex.getParameterName(), ex.getMessage());
+        responseError.setData(data);
+        return new ResponseEntity<>(responseError, HttpStatus.BAD_REQUEST);
+    }
+
     // Handle input validation errors
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ResponseError<Object>> handleValidationException(MethodArgumentNotValidException ex, WebRequest request) {
@@ -51,7 +91,6 @@ public class ExceptionResolver {
     // Handle AppException
     @ExceptionHandler(AppException.class)
     public ResponseEntity<ResponseError<Object>> handleAppException(AppException ex, WebRequest request) {
-        ResponseError<Object> responseError = ResponseError.from(ex);
-        return new ResponseEntity<>(responseError, ex.getStatusCode());
+        return new ResponseEntity<>(ResponseError.from(ex), ex.getStatusCode());
     }
 }

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/configs/security/CustomAuthenticationEntryPoint.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/configs/security/CustomAuthenticationEntryPoint.java
@@ -5,7 +5,6 @@ import com.tranphuc8a.gemini_proxy.domain.exceptions.user.UnauthorizedException;
 import com.tranphuc8a.gemini_proxy.domain.vo.response.ResponseError;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -27,9 +26,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
         UnauthorizedException unauthorizedException =
                 new UnauthorizedException(authException.getMessage());
-        ResponseError<Object> responseError = ResponseError.from(unauthorizedException);
-        ResponseEntity<ResponseError<Object>> body =
-                new ResponseEntity<>(responseError, unauthorizedException.getStatusCode());
+        ResponseError<Object> body = ResponseError.from(unauthorizedException);
 
         response.getWriter().write(objectMapper.writeValueAsString(body));
 

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/in/controllers/ConversationController.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/in/controllers/ConversationController.java
@@ -1,6 +1,23 @@
 package com.tranphuc8a.gemini_proxy.adapter.in.controllers;
 
+import com.tranphuc8a.gemini_proxy.application.ports.input.ConversationInputPort;
+import com.tranphuc8a.gemini_proxy.domain.vo.request.ConversationUpdatingRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +25,109 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/conversation")
 @RequiredArgsConstructor
 public class ConversationController {
+
+    private final ConversationInputPort conversationInputPort;
+
+
+    @Operation(
+            summary = "Get conversation detail",
+            description = "Get conversation detail by conversation id"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Get conversation detail successfully"),
+            @ApiResponse(responseCode = "400", description = "ConversationId is invalid"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "404", description = "Conversation not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error"),
+    })
+    @GetMapping("/{conversationId}")
+    public ResponseEntity<Object> getConversationDetail(
+            @NotNull @NotEmpty @PathVariable("conversationId") String conversationId) {
+        return conversationInputPort.getConversationDetail(conversationId);
+    }
+
+
+    @Operation(
+            summary = "Get conversation messages",
+            description = "Get conversation messages by conversation id"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Get conversation messages successfully"),
+            @ApiResponse(responseCode = "400", description = "ConversationId is invalid"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "404", description = "Conversation not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error"),
+    })
+    @GetMapping("/messages/{conversationId}")
+    public ResponseEntity<Object> getConversationMessages(
+            @NotNull @NotEmpty @PathVariable("conversationId") String conversationId,
+            Pageable pageable) {
+        return conversationInputPort.getConversationMessages(conversationId, pageable);
+    }
+
+
+    @Operation(
+            summary = "Get conversation list",
+            description = "Get conversation list with pagination"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Get conversation list successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "500", description = "Internal server error"),
+    })
+    @GetMapping("/list")
+    public ResponseEntity<Object> getConversationList(Pageable pageable) {
+        return conversationInputPort.getConversationList(pageable);
+    }
+
+
+    @Operation(
+            summary = "Create conversation",
+            description = "Create conversation"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Create conversation successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "500", description = "Internal server error"),
+    })
+    @PostMapping
+    public ResponseEntity<Object> createConversation() {
+        return conversationInputPort.createConversation();
+    }
+
+
+    @Operation(
+            summary = "Update conversation",
+            description = "Update conversation"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Update conversation successfully"),
+            @ApiResponse(responseCode = "400", description = "Conversation Updating Request is invalid"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "500", description = "Internal server error"),
+    })
+    @PatchMapping
+    @PutMapping
+    public ResponseEntity<Object> updateConversation(
+            @Valid @RequestBody ConversationUpdatingRequest conversationUpdatingRequest) {
+        return conversationInputPort.updateConversation(conversationUpdatingRequest);
+    }
+
+
+    @Operation(
+            summary = "Delete conversation",
+            description = "Delete conversation by conversation id"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Delete conversation successfully"),
+            @ApiResponse(responseCode = "400", description = "ConversationId is invalid"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "404", description = "Conversation not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error"),
+    })
+    @DeleteMapping("/{conversationId}")
+    public ResponseEntity<Object> deleteConversation(
+            @NotNull @NotEmpty @PathVariable("conversationId") String conversationId) {
+        return conversationInputPort.deleteConversation(conversationId);
+    }
 }

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/ConversationEntity.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/ConversationEntity.java
@@ -103,8 +103,10 @@ public class ConversationEntity implements TableEntity<Conversation> {
             return this;
         }
         fromDomainLight(domain);
-        messages = domain.getMessages().stream().map(
-                message -> new MessageEntity().fromDomainLight(message)).toList();
+        if (domain.getMessages() != null) {
+            messages = domain.getMessages().stream().map(
+                    message -> new MessageEntity().fromDomainLight(message)).toList();
+        }
         return this;
     }
 

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/MessageEntity.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/entities/MessageEntity.java
@@ -3,6 +3,8 @@ package com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities;
 import com.tranphuc8a.gemini_proxy.domain.enums.Role;
 import com.tranphuc8a.gemini_proxy.domain.models.Message;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -35,6 +37,7 @@ public class MessageEntity implements TableEntity<Message> {
     Integer id;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     Role role;
 
     @Column(nullable = false)

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/repositories/MessageMySQLRepository.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/repositories/MessageMySQLRepository.java
@@ -1,10 +1,14 @@
 package com.tranphuc8a.gemini_proxy.adapter.out.mysql.repositories;
 
 import com.tranphuc8a.gemini_proxy.adapter.out.mysql.entities.MessageEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MessageMySQLRepository extends JpaRepository<MessageEntity, Integer> {
+
+    Page<MessageEntity> getByConversationId(String conversationId, Pageable pageable);
 
 }

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/ConversationMySQLOutputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/ConversationMySQLOutputPort.java
@@ -32,9 +32,10 @@ public class ConversationMySQLOutputPort implements ConversationOutputPort {
     }
 
     @Override
-    public void save(Conversation conversation) {
+    public Conversation save(Conversation conversation) {
         ConversationEntity conversationEntity = new ConversationEntity().fromDomain(conversation);
-        conversationMySQLRepository.save(conversationEntity);
+        conversationEntity = conversationMySQLRepository.save(conversationEntity);
+        return conversationEntity.toDomain();
     }
 
     @Override

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/MessageMySQLOutputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/adapter/out/mysql/services/MessageMySQLOutputPort.java
@@ -31,9 +31,17 @@ public class MessageMySQLOutputPort implements MessageOutputPort {
     }
 
     @Override
-    public void save(Message message) {
+    public Page<Message> getListByConversation(String conversationId, Pageable pageable) {
+        Page<MessageEntity> messageEntityPage
+                = messageMySQLRepository.getByConversationId(conversationId, pageable);
+        return messageEntityPage.map(MessageEntity::toDomain);
+    }
+
+    @Override
+    public Message save(Message message) {
         MessageEntity messageEntity = new MessageEntity().fromDomain(message);
-        messageMySQLRepository.save(messageEntity);
+        messageEntity = messageMySQLRepository.save(messageEntity);
+        return messageEntity.toDomain();
     }
 
     @Override

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/ports/input/ConversationInputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/ports/input/ConversationInputPort.java
@@ -1,4 +1,21 @@
 package com.tranphuc8a.gemini_proxy.application.ports.input;
 
+import com.tranphuc8a.gemini_proxy.domain.vo.request.ConversationUpdatingRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
 public interface ConversationInputPort {
+
+    ResponseEntity<Object> getConversationDetail(String conversationId);
+
+    ResponseEntity<Object> getConversationList(Pageable pageable);
+
+    ResponseEntity<Object> getConversationMessages(String conversationId, Pageable pageable);
+
+    ResponseEntity<Object> createConversation();
+
+    ResponseEntity<Object> updateConversation(ConversationUpdatingRequest conversationUpdatingRequest);
+
+    ResponseEntity<Object> deleteConversation(String conversationId);
+
 }

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/ports/output/ConversationOutputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/ports/output/ConversationOutputPort.java
@@ -10,7 +10,7 @@ public interface ConversationOutputPort {
 
     Page<Conversation> getAll(Pageable pageable);
 
-    void save(Conversation conversation);
+    Conversation save(Conversation conversation);
 
     void delete(Conversation conversation);
 

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/ports/output/MessageOutputPort.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/ports/output/MessageOutputPort.java
@@ -10,7 +10,9 @@ public interface MessageOutputPort {
 
     Page<Message> getAll(Pageable pageable);
 
-    void save(Message message);
+    Page<Message> getListByConversation(String conversationId, Pageable pageable);
+
+    Message save(Message message);
 
     void delete(Message message);
 

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/usecases/ConversationUseCase.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/application/usecases/ConversationUseCase.java
@@ -1,0 +1,96 @@
+package com.tranphuc8a.gemini_proxy.application.usecases;
+
+import com.tranphuc8a.gemini_proxy.application.ports.input.ConversationInputPort;
+import com.tranphuc8a.gemini_proxy.application.ports.output.ConversationOutputPort;
+import com.tranphuc8a.gemini_proxy.application.ports.output.MessageOutputPort;
+import com.tranphuc8a.gemini_proxy.domain.exceptions.user.ResourceNotFoundException;
+import com.tranphuc8a.gemini_proxy.domain.models.Conversation;
+import com.tranphuc8a.gemini_proxy.domain.models.Message;
+import com.tranphuc8a.gemini_proxy.domain.vo.request.ConversationUpdatingRequest;
+import com.tranphuc8a.gemini_proxy.domain.vo.response.ResponseResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ConversationUseCase implements ConversationInputPort {
+
+    public static final int LATEST_MESSAGE_COUNT = 10;
+    public static final String CONVERSATION_NEW_NAME = "New Conversation";
+
+    private final ConversationOutputPort conversationOutputPort;
+
+    private final MessageOutputPort messageOutputPort;
+
+    @Override
+    public ResponseEntity<Object> getConversationDetail(String conversationId) {
+        Conversation conversation = conversationOutputPort.getById(conversationId);
+        if (conversation == null) {
+            throw new ResourceNotFoundException("Conversation not found");
+        }
+        conversation.setMessages(
+                conversation.getMessages().stream().limit(LATEST_MESSAGE_COUNT).toList()
+        );
+        return ResponseEntity.ok(ResponseResult.from(
+                conversation, "Get conversation detail successfully"));
+    }
+
+    @Override
+    public ResponseEntity<Object> getConversationList(Pageable pageable) {
+        Page<Conversation> conversationPage = conversationOutputPort.getAll(pageable);
+        conversationPage.forEach(conversation -> conversation.setMessages(List.of()));
+        return ResponseEntity.ok(ResponseResult.from(
+                conversationPage, "Get conversation list successfully"));
+    }
+
+    @Override
+    public ResponseEntity<Object> getConversationMessages(String conversationId, Pageable pageable) {
+        Conversation conversation = conversationOutputPort.getById(conversationId);
+        if (conversation == null) {
+            throw new ResourceNotFoundException("Conversation not found");
+        }
+        Page<Message> messagePage = messageOutputPort.getListByConversation(conversationId, pageable);
+        messagePage.forEach(message -> message.setConversation(null));
+        return ResponseEntity.ok(ResponseResult.from(
+                messagePage, "Get conversation messages successfully"));
+    }
+
+    @Override
+    public ResponseEntity<Object> createConversation() {
+        Conversation conversation = Conversation.builder()
+                .id(null)
+                .name(CONVERSATION_NEW_NAME)
+                .build();
+        conversation = conversationOutputPort.save(conversation);
+        return ResponseEntity.ok(ResponseResult.from(
+                conversation, "Create conversation successfully"));
+    }
+
+    @Override
+    public ResponseEntity<Object> updateConversation(ConversationUpdatingRequest conversationUpdatingRequest) {
+        Conversation conversation = conversationOutputPort.getById(conversationUpdatingRequest.getConversationId());
+        if (conversation == null) {
+            throw new ResourceNotFoundException("Conversation not found");
+        }
+        conversation.setName(conversationUpdatingRequest.getName());
+        conversation = conversationOutputPort.save(conversation);
+        return ResponseEntity.ok(ResponseResult.from(
+                conversation, "Update conversation successfully"));
+    }
+
+    @Override
+    public ResponseEntity<Object> deleteConversation(String conversationId) {
+        Conversation conversation = conversationOutputPort.getById(conversationId);
+        if (conversation == null) {
+            throw new ResourceNotFoundException("Conversation not found");
+        }
+        conversationOutputPort.delete(conversation);
+        return ResponseEntity.ok(ResponseResult.from(
+                conversation, "Delete conversation successfully"));
+    }
+}

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/domain/models/Conversation.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/domain/models/Conversation.java
@@ -1,5 +1,7 @@
 package com.tranphuc8a.gemini_proxy.domain.models;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
@@ -11,10 +13,12 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Conversation {
     String id;
     String name;
     LocalDateTime createdAt;
     LocalDateTime updatedAt;
-    List<Message> messages;
+    @Builder.Default
+    List<Message> messages = List.of();
 }

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/domain/models/Message.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/domain/models/Message.java
@@ -1,5 +1,7 @@
 package com.tranphuc8a.gemini_proxy.domain.models;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.tranphuc8a.gemini_proxy.domain.enums.Role;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
@@ -11,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 @FieldDefaults(level = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Message {
     Integer id;
     Conversation conversation;

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/domain/vo/request/ConversationUpdatingRequest.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/domain/vo/request/ConversationUpdatingRequest.java
@@ -1,0 +1,32 @@
+package com.tranphuc8a.gemini_proxy.domain.vo.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ConversationUpdatingRequest {
+
+    @NotNull
+    @NotEmpty
+    String conversationId;
+
+    @NotNull
+    @NotEmpty
+    String name;
+
+}

--- a/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/domain/vo/response/ResponseResult.java
+++ b/backend/gemini-proxy/src/main/java/com/tranphuc8a/gemini_proxy/domain/vo/response/ResponseResult.java
@@ -2,8 +2,13 @@ package com.tranphuc8a.gemini_proxy.domain.vo.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.http.HttpStatus;
 
 import java.io.Serializable;
 
@@ -13,6 +18,27 @@ import java.io.Serializable;
 @AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class ResponseResult implements Serializable {
+public class ResponseResult<T> implements Serializable {
     int statusCode;
+    String userMessage;
+    String devMessage;
+    T data;
+
+    public static <T> ResponseResult<T> from(T data, String userMessage) {
+        return ResponseResult.<T>builder()
+                .statusCode(HttpStatus.OK.value())
+                .userMessage(userMessage)
+                .devMessage(userMessage)
+                .data(data)
+                .build();
+    }
+
+    public static <T> ResponseResult<T> from(T data) {
+        return ResponseResult.<T>builder()
+                .statusCode(HttpStatus.OK.value())
+                .userMessage(HttpStatus.OK.getReasonPhrase())
+                .devMessage(HttpStatus.OK.getReasonPhrase())
+                .data(data)
+                .build();
+    }
 }


### PR DESCRIPTION

### Implement APIs for conservation

### Features

- Features `conversation`:
  - Basic **CRUD**
  - In package `adapter`:
    - Add `controllers`, `input ports` and `usecases`
  - Modify `CustomAuthenticationEntryPoint` and add some exception handings in `ExceptionResolver`
  - Add models in package `vo.request, vo.response`


### Documents

- Confluence: [Confluence](https://tranphuc9a.atlassian.net/wiki/x/aoIj)

