### PR TITLE
[GP-46] cicd: Update step upload jacoco report artifact in test_on_pr.be

### DIFF
--- a/.github/workflows/test_on_pr.be.yml
+++ b/.github/workflows/test_on_pr.be.yml
@@ -6,8 +6,7 @@ on:
       - main
     paths:
       - 'backend/**'
-      - 'cicd/**'
-      - 'database/**'
+      - '.github/workflows/**'
     types: [opened, synchronize, reopened, edited, ready_for_review, labeled]
 
   push:
@@ -52,17 +51,14 @@ jobs:
       - name: Run tests with Jacoco
         run: mvn clean test jacoco:report -f pom.xml
 
-
       - name: Archive jacoco report
         run: zip -r jacoco-report.zip target/site/jacoco
-      
       
       - name: Upload jacoco report artifact
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-report
           path: backend/gemini-proxy/jacoco-report.zip
-
 
       - name: Verify build status
         run: echo "✅ Backend PR CI completed successfully"


### PR DESCRIPTION
### Changes

- In `.github.workflows.test_on_pr.be.yaml`:
  - Add step compress folder then upload zip file
  - Update path to trigger test_on_pr.be ([9513625fa](https://github.com/tranphuc8a/gemini_proxy/pull/47/commits/9513625fa5b23303743c758f1ebd16a20f982070))

### Documents

- N/A
